### PR TITLE
LineNotificationControllerの修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      postgres:
+    # postgres:
+      db:
         image: postgres
         env:
           POSTGRES_USER: postgres

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -30,7 +30,7 @@ class EventsController < ApplicationController
   end
 
   def calendar
-    @events = Event.viewable_by(current_user).joins(:participants).where(participants: { user_id: current_user.id })
+    @events = Event.joins(:participants).where(participants: { user_id: current_user.id })
   end
 
   def new


### PR DESCRIPTION
- send_line_notification の責任を「LINE通知を送信すること」のみとする。

- ユーザー情報の取得は send_notification 内で一括管理。