### PR TITLE
参加ボタン表示の修正

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -28,7 +28,8 @@ class Event < ApplicationRecord
 
   # 募集状態を更新するメソッド
   def update_registration_status
-    if date.past? || (capacity.present? && participants.count >= capacity)
+   # if date.past? || (capacity.present? && participants.count >= capacity)
+   if date.past?
       close_registration
     else
       open_registration
@@ -39,7 +40,7 @@ class Event < ApplicationRecord
   def registration_open?
     return false if status == "closed"
     return false if date.past? # 過去のイベントは募集終了
-    return false if capacity.present? && participants.count >= capacity # 定員に達しているイベントは募集終了
+    # return false if capacity.present? && participants.count >= capacity # 定員に達しているイベントは募集終了
 
     true # それ以外は募集中
   end

--- a/app/views/events/_toggle_button.html.erb
+++ b/app/views/events/_toggle_button.html.erb
@@ -4,7 +4,7 @@
     <%= button_to event.registration_open? ? '募集中' : '募集終了', toggle_registration_event_path(event), remote: true, class: "btn #{event.registration_open? ? 'btn-success' : 'btn-secondary'}", id: "button_container_#{event.id}" %>
   <% else %>
     <%# 参加者の場合 %>
-    <% if event.registration_open? %>
+    <% if event.registration_open? && (current_user.participating?(event) || (event.capacity.blank? || event.participants.count < event.capacity)) %>
       <%= button_to current_user.participating?(event) ? '参加中' : '参加する', toggle_participation_event_path(event), remote: true, class: "btn #{current_user.participating?(event) ? 'btn-secondary' : 'btn-warning'}", id: "button_container_#{event.id}" %>
     <% end %>
   <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -6,8 +6,8 @@
         <div class="col-12 col-md-9 d-flex flex-row align-items-center">
           <!-- アイコン -->
           <div class="col-4 col-md-4 d-flex flex-column justify-content-center align-items-center">
-            <%= image_tag @profile.avatar, class: 'img-fluid', style: 'width: 100px; height: 100px;' %>
-            <h5 class="card-text fw-normal mb-3 text-center"><%= @profile.name %></h5>
+            <%= image_tag @profile.avatar, class: 'img-fluid mb-2', style: 'width: 100px; height: 100px;' %>
+            <h6 class="card-text mb-3 text-center"><%= @profile.name %></h6>
           </div>
 
           <!-- 詳細 -->


### PR DESCRIPTION
定員に達したとき、募集を終了するのではなく、参加ボタンが表示されないように修正。
→参加者が抜けて定員割れしたときにわざわざ募集再開する必要がなくなる。